### PR TITLE
Add a null check for selectedInstance

### DIFF
--- a/dist/InfiniteCraftHelper.user.js
+++ b/dist/InfiniteCraftHelper.user.js
@@ -485,7 +485,8 @@
 	                            unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0].setInstancePosition(unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance, e.clientX - width / 2, e.clientY - height / 2);
 	                            unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0].setInstanceZIndex(unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance, data.id);
 	                            unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance.elem.addEventListener('mouseup', exportFunction((e) => {
-	                                if (!unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance.hasMoved) {
+	                                if (unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance &&
+	                                    !unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance.hasMoved) {
 	                                    unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance.hasMoved =
 	                                        true;
 	                                    unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0].calcInstanceSize(unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance);

--- a/script/copy.ts
+++ b/script/copy.ts
@@ -61,6 +61,7 @@ export function setMiddleClickOnMutations(mutations: MutationRecord[], elements:
 									'mouseup',
 									exportFunction((e: MouseEvent) => {
 										if (
+                                            unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance &&
 											!unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance.hasMoved
 										) {
 											unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance.hasMoved =

--- a/script/copy.ts
+++ b/script/copy.ts
@@ -61,7 +61,7 @@ export function setMiddleClickOnMutations(mutations: MutationRecord[], elements:
 									'mouseup',
 									exportFunction((e: MouseEvent) => {
 										if (
-                                            unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance &&
+											unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance &&
 											!unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance.hasMoved
 										) {
 											unsafeWindow.$nuxt.$root.$children[2].$children[0].$children[0]._data.selectedInstance.hasMoved =


### PR DESCRIPTION
When you delete an instance with right click and trigger the `mouseup` event before the scale animation has finished playing, the script will try to check for `selectedInstance.hasMoved`. But since it's already set to null, an ugly error gets thrown into the console.